### PR TITLE
Add functions to access existing modules in a scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
-    /// return the existing definition instead.
+    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
+    /// will return the existing definition instead.
     /// 
-    /// [`get_or_new_module`]: #method.get_or_new_module
+    /// [`get_or_add_module`]: #method.get_or_add_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.push_module(Module::new(name));
 
@@ -319,7 +319,7 @@ impl Scope {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
+    pub fn get_or_add_module(&mut self, name: &str) -> &mut Module {
         if self.modules.contains_key(name) {
             &mut self.modules[name]
         } else {
@@ -335,10 +335,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
-    /// return the existing definition instead.
+    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
+    /// will return the existing definition instead.
     /// 
-    /// [`get_or_new_module`]: #method.get_or_new_module
+    /// [`get_or_add_module`]: #method.get_or_add_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         assert!(self.get_module(&item.name).is_none());
         self.items.push(Item::Module(item.name.clone()));
@@ -553,10 +553,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
-    /// return the existing definition instead.
+    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
+    /// will return the existing definition instead.
     /// 
-    /// [`get_or_new_module`]: #method.get_or_new_module
+    /// [`get_or_add_module`]: #method.get_or_add_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.scope.new_module(name)
     }
@@ -581,8 +581,8 @@ impl Module {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
-        self.scope.get_or_new_module(name)
+    pub fn get_or_add_module(&mut self, name: &str) -> &mut Module {
+        self.scope.get_or_add_module(name)
     }
 
     /// Push a module definition.
@@ -593,10 +593,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
-    /// return the existing definition instead.
+    /// In many cases, the [`get_or_add_module`] function is preferrable, as it
+    /// will return the existing definition instead.
     /// 
-    /// [`get_or_new_module`]: #method.get_or_new_module
+    /// [`get_or_add_module`]: #method.get_or_add_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         self.scope.push_module(item);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,16 +263,16 @@ impl Scope {
     }
 
     /// Push a new module definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// Since a module's name must uniquely identify it within the scope in 
+    ///
+    /// Since a module's name must uniquely identify it within the scope in
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
-    /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it 
+    ///
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it
     /// will return the existing definition instead.
-    /// 
+    ///
     /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.push_module(Module::new(name));
@@ -283,10 +283,10 @@ impl Scope {
         }
     }
 
-    /// Returns a mutable reference to a module if it is exists in this scope. 
-    pub fn get_module_mut<Q: ?Sized>(&mut self, 
-                                     name: &Q) 
-                                     -> Option<&mut Module> 
+    /// Returns a mutable reference to a module if it is exists in this scope.
+    pub fn get_module_mut<Q: ?Sized>(&mut self,
+                                     name: &Q)
+                                     -> Option<&mut Module>
     where
         String: PartialEq<Q>,
     {
@@ -298,9 +298,8 @@ impl Scope {
             })
             .next()
     }
-    
 
-    /// Returns a mutable reference to a module if it is exists in this scope. 
+    /// Returns a mutable reference to a module if it is exists in this scope.
     pub fn get_module<Q: ?Sized>(&self, name: &Q) -> Option<&Module>
     where
         String: PartialEq<Q>,
@@ -314,7 +313,7 @@ impl Scope {
             .next()
     }
 
-    /// Returns a mutable reference to a module, creating it if it does 
+    /// Returns a mutable reference to a module, creating it if it doesn
     /// not exist.
     pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
         if self.get_module(name).is_some() {
@@ -325,16 +324,16 @@ impl Scope {
     }
 
     /// Push a module definition.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// Since a module's name must uniquely identify it within the scope in 
+    ///
+    /// Since a module's name must uniquely identify it within the scope in
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
-    /// 
+    ///
     /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
-    /// 
+    ///
     /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         assert!(self.get_module(&item.name).is_none());
@@ -542,22 +541,22 @@ impl Module {
     }
 
     /// Push a new module definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// Since a module's name must uniquely identify it within the scope in 
+    ///
+    /// Since a module's name must uniquely identify it within the scope in
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
-    /// 
-    /// In many cases, the [`get_or_new_module`] function is preferrable, as it 
+    ///
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it
     /// will return the existing definition instead.
-    /// 
+    ///
     /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.scope.new_module(name)
     }
 
-    /// Returns a reference to a module if it is exists in this scope. 
+    /// Returns a reference to a module if it is exists in this scope.
     pub fn get_module<Q: ?Sized>(&self, name: &Q) -> Option<&Module>
     where
         String: PartialEq<Q>,
@@ -565,39 +564,38 @@ impl Module {
         self.scope.get_module(name)
     }
 
-    /// Returns a mutable reference to a module if it is exists in this scope. 
-    pub fn get_module_mut<Q: ?Sized>(&mut self, 
-                                     name: &Q) 
-                                     -> Option<&mut Module> 
+    /// Returns a mutable reference to a module if it is exists in this scope.
+    pub fn get_module_mut<Q: ?Sized>(&mut self,
+                                     name: &Q)
+                                     -> Option<&mut Module>
     where
         String: PartialEq<Q>,
     {
         self.scope.get_module_mut(name)
     }
 
-    /// Returns a mutable reference to a module, creating it if it does 
+    /// Returns a mutable reference to a module, creating it if it does
     /// not exist.
     pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
         self.scope.get_or_new_module(name)
     }
 
     /// Push a module definition.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// Since a module's name must uniquely identify it within the scope in 
+    ///
+    /// Since a module's name must uniquely identify it within the scope in
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
-    /// 
+    ///
     /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
-    /// 
+    ///
     /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         self.scope.push_module(item);
         self
     }
-
 
     /// Push a new struct definition, returning a mutable reference to it.
     pub fn new_struct(&mut self, name: &str) -> &mut Struct {
@@ -1255,7 +1253,6 @@ impl Fields {
         Ok(())
     }
 }
-
 
 // ===== impl Impl =====
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl Scope {
             .next()
     }
 
-    /// Returns a mutable reference to a module, creating it if it doesn
+    /// Returns a mutable reference to a module, creating it if it does
     /// not exist.
     pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
         if self.get_module(name).is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,8 +250,7 @@ pub struct Formatter<'a> {
     /// Write destination
     dst: &'a mut String,
 
-    /// Number of spaces to start a new line with
-    /// 
+    /// Number of spaces to start a new line with.
     spaces: usize,
 
     /// Number of spaces per indentiation
@@ -293,11 +292,11 @@ impl Scope {
 
     /// Push a new module definition, returning a mutable reference to it.
     /// 
-    /// # Note
+    /// # Panics
     /// 
     /// Since a module's name must uniquely identify it within the scope in 
-    /// which it is defined, calling this function with a name already used 
-    /// in this scope will (silently) clobber the existing module definition.
+    /// which it is defined, pushing a module whose name is already defined
+    /// in this scope will cause this function to panic.
     /// 
     /// In many cases, the [`module_or_add`] function is preferrable, as it will
     /// return the existing definition instead.
@@ -339,17 +338,18 @@ impl Scope {
 
     /// Push a module definition.
     /// 
-    /// # Note
+    /// # Panics
     /// 
     /// Since a module's name must uniquely identify it within the scope in 
     /// which it is defined, pushing a module whose name is already defined
-    /// in this scope will clobber the existing module definition.
+    /// in this scope will cause this function to panic.
     /// 
     /// In many cases, the [`module_or_add`] function is preferrable, as it will
     /// return the existing definition instead.
     /// 
     /// [`module_or_add`]: #method.module_or_add
     pub fn push_module(&mut self, item: Module) -> &mut Self {
+        assert!(self.get_module(&item.name).is_none());
         self.items.push(Item::Module(item.name.clone()));
         self.modules.insert(RcKey(item.name.clone()), item);
         self
@@ -559,11 +559,11 @@ impl Module {
 
     /// Push a new module definition, returning a mutable reference to it.
     /// 
-    /// # Note
+    /// # Panics
     /// 
     /// Since a module's name must uniquely identify it within the scope in 
-    /// which it is defined, calling this function with a name already used 
-    /// in this scope will (silently) clobber the existing module definition.
+    /// which it is defined, pushing a module whose name is already defined
+    /// in this scope will cause this function to panic.
     /// 
     /// In many cases, the [`module_or_add`] function is preferrable, as it will
     /// return the existing definition instead.
@@ -599,11 +599,11 @@ impl Module {
 
     /// Push a module definition.
     /// 
-    /// # Note
+    /// # Panics
     /// 
     /// Since a module's name must uniquely identify it within the scope in 
     /// which it is defined, pushing a module whose name is already defined
-    /// in this scope will clobber the existing module definition.
+    /// in this scope will cause this function to panic.
     /// 
     /// In many cases, the [`module_or_add`] function is preferrable, as it will
     /// return the existing definition instead.
@@ -1752,5 +1752,12 @@ impl Borrow<str> for RcKey {
     #[inline]
     fn borrow(&self) -> &str {
         self.0.as_ref()
+    }
+}
+
+impl Borrow<Rc<String>> for RcKey {
+    #[inline]
+    fn borrow(&self) -> &Rc<String> {
+        &self.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,22 @@ impl Scope {
         }
     }
 
+    /// Returns a mutable reference to a module if it is exists in this scope. 
+    pub fn module_mut(&mut self, name: &str) -> Option<&mut Module> {
+        // TODO: we'd get better performance from changing `items` to an
+        // `OrderMap` keyed by the name of the item...
+        self.items.iter_mut()
+            .find(|i| match *i {
+                &mut Item::Module(ref m) => m.name == name,
+                _ => false,
+            })
+            // XXX this is ugly...
+            .map(|i| 
+                if let Item::Module(ref mut m) = *i { m } 
+                else { unreachable!() }
+            )
+    }
+
     /// Push a module definition.
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         self.items.push(Item::Module(item));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`module_or_add`] function is preferrable, as it will
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
     /// 
-    /// [`module_or_add`]: #method.module_or_add
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.push_module(Module::new(name));
 
@@ -319,7 +319,7 @@ impl Scope {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn module_or_add(&mut self, name: &str) -> &mut Module {
+    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
         if self.modules.contains_key(name) {
             &mut self.modules[name]
         } else {
@@ -335,10 +335,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`module_or_add`] function is preferrable, as it will
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
     /// 
-    /// [`module_or_add`]: #method.module_or_add
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         assert!(self.get_module(&item.name).is_none());
         self.items.push(Item::Module(item.name.clone()));
@@ -553,10 +553,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`module_or_add`] function is preferrable, as it will
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
     /// 
-    /// [`module_or_add`]: #method.module_or_add
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.scope.new_module(name)
     }
@@ -581,8 +581,8 @@ impl Module {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn module_or_add(&mut self, name: &str) -> &mut Module {
-        self.scope.module_or_add(name)
+    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
+        self.scope.get_or_new_module(name)
     }
 
     /// Push a module definition.
@@ -593,10 +593,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`module_or_add`] function is preferrable, as it will
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
     /// return the existing definition instead.
     /// 
-    /// [`module_or_add`]: #method.module_or_add
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         self.scope.push_module(item);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ pub struct Formatter<'a> {
     dst: &'a mut String,
 
     /// Number of spaces to start a new line with
+    /// 
     spaces: usize,
 
     /// Number of spaces per indentiation
@@ -291,7 +292,7 @@ impl Scope {
     }
 
     /// Returns true if a module named `name` exists in this scope.
-    pub fn cotnains_module<Q: ?Sized>(&self, name: &Q) -> bool 
+    pub fn contains_module<Q: ?Sized>(&self, name: &Q) -> bool 
     where
         Q: Hash + ordermap::Equivalent<RcKey>
     {
@@ -551,6 +552,13 @@ impl Module {
         self
     }
 
+    /// Returns true if a module named `name` exists in this scope.
+    pub fn contains_module<Q: ?Sized>(&self, name: &Q) -> bool 
+    where
+        Q: Hash + ordermap::Equivalent<RcKey>
+    {
+        self.scope.contains_module(name)
+    }
 
     /// Push a new module definition, returning a mutable reference to it.
     /// 
@@ -566,6 +574,17 @@ impl Module {
     /// [`module_or_add`]: #method.module_or_add
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.scope.new_module(name)
+    }
+
+    /// Returns a mutable reference to a module if it is exists in this scope. 
+    pub fn module_mut(&mut self, name: &str) -> Option<&mut Module> {
+        self.scope.module_mut(name)
+    }
+
+    /// Returns a mutable reference to a module, creating it if it does 
+    /// not exist.
+    pub fn module_or_add(&mut self, name: &str) -> &mut Module {
+        self.scope.module_or_add(name)
     }
 
     /// Push a module definition.
@@ -584,6 +603,7 @@ impl Module {
         self.scope.push_module(item);
         self
     }
+
 
     /// Push a new struct definition, returning a mutable reference to it.
     pub fn new_struct(&mut self, name: &str) -> &mut Struct {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ use ordermap::OrderMap;
 use std::fmt::{self, Write};
 use std::rc::Rc;
 use std::borrow::Borrow;
-use std::hash::Hash;
 
 /// Defines a scope.
 ///
@@ -51,25 +50,6 @@ pub struct Scope {
     /// Contents of the documentation,
     items: Vec<Item>,
 }
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
-struct RcKey(Rc<String>);
-
-impl<K> std::cmp::PartialEq<K> for RcKey 
-where 
-    K: Borrow<String>,
-    K: Hash + Eq, 
-{
-    fn eq(&self, key: &K) -> bool {
-        *key.borrow() == *self.0
-    }
-}
-
-impl Borrow<str> for RcKey {
-    fn borrow(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
 #[derive(Debug, Clone)]
 enum Item {
     Module(Rc<String>),
@@ -263,6 +243,13 @@ pub struct Formatter<'a> {
     /// Number of spaces per indentiation
     indent: usize,
 }
+
+/// Newtype wrapping a `Rc<String>` so it can be used more easily as a hash key.
+/// 
+/// In this case, we wrap `Rc<String>`s in `RcKey` so we can implement 
+/// `Borrow<str>` for it.
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+struct RcKey(Rc<String>);
 
 const DEFAULT_INDENT: usize = 4;
 
@@ -1659,5 +1646,14 @@ impl<'a> fmt::Write for Formatter<'a> {
         }
 
         Ok(())
+    }
+}
+
+// ===== impl RcKey =====
+
+impl Borrow<str> for RcKey {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.0.as_ref()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,16 +291,12 @@ impl Scope {
         String: PartialEq<Q>,
     {
         self.items.iter_mut()
-            .find(|item| if let &mut Item::Module(ref module) = *item { 
-                module.name == *name 
-            } else {
-                false
+            .filter_map(|item| match item {
+                &mut Item::Module(ref mut module) if module.name == *name =>
+                    Some(module),
+                _ => None,
             })
-            .map(|item| if let Item::Module(ref mut module) = *item { 
-                module
-            } else {
-                unreachable!()
-            })
+            .next()
     }
     
 
@@ -310,16 +306,12 @@ impl Scope {
         String: PartialEq<Q>,
     {
         self.items.iter()
-            .find(|item| if let &Item::Module(ref module) = *item { 
-                module.name == *name 
-            } else {
-                false
+            .filter_map(|item| match item {
+                &Item::Module(ref module) if module.name == *name =>
+                    Some(module),
+                _ => None,
             })
-            .map(|item| if let Item::Module(ref module) = *item { 
-                module
-            } else {
-                unreachable!()
-            })
+            .next()
     }
 
     /// Returns a mutable reference to a module, creating it if it does 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,11 +328,11 @@ impl Scope {
         }
     }
 
-    // /// Push a trait definition
-    // pub fn push_trait(&mut self, item: Trait) -> &mut Self {
-    //     self.items.insert(item.name.clone(), Item::Trait(item));
-    //     self
-    // }
+    /// Push a trait definition
+    pub fn push_trait(&mut self, name: &str, item: Trait) -> &mut Self {
+        self.items.insert(name.to_string(), Item::Trait(item));
+        self
+    }
 
     /// Push a new struct definition, returning a mutable reference to it.
     pub fn new_enum(&mut self, name: &str) -> &mut Enum {
@@ -352,7 +352,7 @@ impl Scope {
 
     /// Push a new `impl` block, returning a mutable reference to it.
     pub fn new_impl(&mut self, target: &str) -> &mut Impl {
-        self.items.insert(target.to_owned(), Item::Impl(Impl::new(target)));
+        self.items.insert(target.to_string(), Item::Impl(Impl::new(target)));
 
         match self.items[target] {
             Item::Impl(ref mut v) => v,
@@ -360,11 +360,11 @@ impl Scope {
         }
     }
 
-    // /// Push an `impl` block.
-    // pub fn push_impl(&mut self, item: Impl) -> &mut Self {
-    //     self.items.push(Item::Impl(item));
-    //     self
-    // }
+    /// Push an `impl` block.
+    pub fn push_impl(&mut self, name: &str, item: Impl) -> &mut Self {
+        self.items.insert(name.to_string(), Item::Impl(item));
+        self
+    }
 
     /// Push a raw string to the scope.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
-    /// will return the existing definition instead.
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
+    /// return the existing definition instead.
     /// 
-    /// [`get_or_add_module`]: #method.get_or_add_module
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.push_module(Module::new(name));
 
@@ -319,7 +319,7 @@ impl Scope {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn get_or_add_module(&mut self, name: &str) -> &mut Module {
+    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
         if self.modules.contains_key(name) {
             &mut self.modules[name]
         } else {
@@ -335,10 +335,10 @@ impl Scope {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
-    /// will return the existing definition instead.
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
+    /// return the existing definition instead.
     /// 
-    /// [`get_or_add_module`]: #method.get_or_add_module
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         assert!(self.get_module(&item.name).is_none());
         self.items.push(Item::Module(item.name.clone()));
@@ -553,10 +553,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_add_module`] function is preferrable, as it 
-    /// will return the existing definition instead.
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
+    /// return the existing definition instead.
     /// 
-    /// [`get_or_add_module`]: #method.get_or_add_module
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn new_module(&mut self, name: &str) -> &mut Module {
         self.scope.new_module(name)
     }
@@ -581,8 +581,8 @@ impl Module {
 
     /// Returns a mutable reference to a module, creating it if it does 
     /// not exist.
-    pub fn get_or_add_module(&mut self, name: &str) -> &mut Module {
-        self.scope.get_or_add_module(name)
+    pub fn get_or_new_module(&mut self, name: &str) -> &mut Module {
+        self.scope.get_or_new_module(name)
     }
 
     /// Push a module definition.
@@ -593,10 +593,10 @@ impl Module {
     /// which it is defined, pushing a module whose name is already defined
     /// in this scope will cause this function to panic.
     /// 
-    /// In many cases, the [`get_or_add_module`] function is preferrable, as it
-    /// will return the existing definition instead.
+    /// In many cases, the [`get_or_new_module`] function is preferrable, as it will
+    /// return the existing definition instead.
     /// 
-    /// [`get_or_add_module`]: #method.get_or_add_module
+    /// [`get_or_new_module`]: #method.get_or_new_module
     pub fn push_module(&mut self, item: Module) -> &mut Self {
         self.scope.push_module(item);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,14 +291,6 @@ impl Scope {
             .or_insert_with(|| Import::new(path, ty))
     }
 
-    /// Returns true if a module named `name` exists in this scope.
-    pub fn contains_module<Q: ?Sized>(&self, name: &Q) -> bool 
-    where
-        Q: Hash + ordermap::Equivalent<RcKey>
-    {
-        self.modules.contains_key(name)
-    }
-
     /// Push a new module definition, returning a mutable reference to it.
     /// 
     /// # Note
@@ -318,8 +310,21 @@ impl Scope {
     }
 
     /// Returns a mutable reference to a module if it is exists in this scope. 
-    pub fn module_mut(&mut self, name: &str) -> Option<&mut Module> {
+    pub fn get_module_mut<Q: ?Sized>(&mut self, 
+                                     name: &Q) 
+                                     -> Option<&mut Module> 
+    where
+        Q: Hash + ordermap::Equivalent<RcKey>,
+    {
         self.modules.get_mut(name)
+    }
+
+    /// Returns a mutable reference to a module if it is exists in this scope. 
+    pub fn get_module<Q: ?Sized>(&self, name: &Q) -> Option<&Module>
+    where
+        Q: Hash + ordermap::Equivalent<RcKey>,
+    {
+        self.modules.get(name)
     }
 
     /// Returns a mutable reference to a module, creating it if it does 
@@ -552,14 +557,6 @@ impl Module {
         self
     }
 
-    /// Returns true if a module named `name` exists in this scope.
-    pub fn contains_module<Q: ?Sized>(&self, name: &Q) -> bool 
-    where
-        Q: Hash + ordermap::Equivalent<RcKey>
-    {
-        self.scope.contains_module(name)
-    }
-
     /// Push a new module definition, returning a mutable reference to it.
     /// 
     /// # Note
@@ -576,9 +573,22 @@ impl Module {
         self.scope.new_module(name)
     }
 
+    /// Returns a reference to a module if it is exists in this scope. 
+    pub fn get_module<Q: ?Sized>(&self, name: &Q) -> Option<&Module> 
+    where
+        Q: Hash + ordermap::Equivalent<RcKey>,
+    {
+        self.scope.get_module(name)
+    }
+
     /// Returns a mutable reference to a module if it is exists in this scope. 
-    pub fn module_mut(&mut self, name: &str) -> Option<&mut Module> {
-        self.scope.module_mut(name)
+    pub fn get_module_mut<Q: ?Sized>(&mut self, 
+                                     name: &Q) 
+                                     -> Option<&mut Module> 
+    where
+        Q: Hash + ordermap::Equivalent<RcKey>,
+    {
+        self.scope.get_module_mut(name)
     }
 
     /// Returns a mutable reference to a module, creating it if it does 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -247,7 +247,7 @@ fn module_mut() {
         .import("bar", "Bar")
         ;
 
-    scope.module_mut("foo").expect("module_mut")
+    scope.get_module_mut("foo").expect("module_mut")
         .new_struct("Foo")
         .field("bar", "Bar")
         ;
@@ -267,7 +267,7 @@ mod foo {
 #[test]
 fn module_or_add() {
     let mut scope = Scope::new();
-    assert!(scope.module_mut("foo").is_none());
+    assert!(scope.get_module("foo").is_none());
 
     scope.module_or_add("foo")
         .import("bar", "Bar")

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -263,3 +263,29 @@ mod foo {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+#[test]
+fn module_or_add() {
+    let mut scope = Scope::new();
+    assert!(scope.module_mut("foo").is_none());
+
+    scope.module_or_add("foo")
+        .import("bar", "Bar")
+        ;
+    
+    scope.module_or_add("foo")
+        .new_struct("Foo")
+        .field("bar", "Bar")
+        ;
+
+    let expect = r#"
+mod foo {
+    use bar::Bar;
+
+    struct Foo {
+        bar: Bar,
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -263,3 +263,29 @@ mod foo {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+#[test]
+fn module_or_add() {
+    let mut scope = Scope::new();
+    assert!(scope.module_mut("foo").is_none());
+
+    scope.module("foo")
+        .import("bar", "Bar")
+        ;
+    
+    scope.module("foo")
+        .new_struct("Foo")
+        .field("bar", "Bar")
+        ;
+
+    let expect = r#"
+mod foo {
+    use bar::Bar;
+
+    struct Foo {
+        bar: Bar,
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -272,7 +272,7 @@ fn get_or_new_module() {
     scope.get_or_new_module("foo")
         .import("bar", "Bar")
         ;
-    
+
     scope.get_or_new_module("foo")
         .new_struct("Foo")
         .field("bar", "Bar")

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -263,29 +263,3 @@ mod foo {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
-
-#[test]
-fn module_or_add() {
-    let mut scope = Scope::new();
-    assert!(scope.module_mut("foo").is_none());
-
-    scope.module("foo")
-        .import("bar", "Bar")
-        ;
-    
-    scope.module("foo")
-        .new_struct("Foo")
-        .field("bar", "Bar")
-        ;
-
-    let expect = r#"
-mod foo {
-    use bar::Bar;
-
-    struct Foo {
-        bar: Bar,
-    }
-}"#;
-
-    assert_eq!(scope.to_string(), &expect[1..]);
-}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -265,15 +265,15 @@ mod foo {
 }
 
 #[test]
-fn module_or_add() {
+fn get_or_new_module() {
     let mut scope = Scope::new();
     assert!(scope.get_module("foo").is_none());
 
-    scope.module_or_add("foo")
+    scope.get_or_new_module("foo")
         .import("bar", "Bar")
         ;
     
-    scope.module_or_add("foo")
+    scope.get_or_new_module("foo")
         .new_struct("Foo")
         .field("bar", "Bar")
         ;

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -238,3 +238,28 @@ mod foo {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+
+#[test]
+fn module_mut() {
+    let mut scope = Scope::new();
+    scope.new_module("foo")
+        .import("bar", "Bar")
+        ;
+
+    scope.module_mut("foo").expect("module_mut")
+        .new_struct("Foo")
+        .field("bar", "Bar")
+        ;
+
+    let expect = r#"
+mod foo {
+    use bar::Bar;
+
+    struct Foo {
+        bar: Bar,
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}


### PR DESCRIPTION
While working on tower-rs/tower-grpc#9, I found that I sometimes had the need to access a module by name when it had previously been created in a given scope.

## Changes

I've added the following new functions on the `Scope` and `Module` types:

- `module_mut` _optionally_ returns `&mut Module` if a scope contains a module with the given name.
- `module_or_add` returns `&mut Module` if a scope contains a module with the given name, or creates it and returns a mut reference to it if it does not yet exist.
- `contains_module` returns true if a scope contains a module with the given name.

I've also added a handful of unit tests for `module_mut` and `module_or_add`.

After experimenting with a number of ways to implement this functionality, I settled on storing the `Module`s defined in a `Scope` in an `OrderMap` separate from the scope's `items` vec. I changed `Item::Module` so that, rather than owning the `Module`, it stores the name of the module so that when the `items` vector is iterated over, it can access the module by looking it up in the `modules` map. The names of `Module`s are now reference counted, so that we can reuse the same string for the name stored in the `Module` struct itself, the key in the `modules` map, and the key stored in `Item::Module`. 

## Questions

- I'm not convinced `module_or_add` is the best name for the "return a module if it exists, or else create it" method, but couldn't come up with a better one. If anyone could think of a name that better describes the function's behaviour without being overly verbose, that would be greatly appreciated. (I considered just calling it `module` but thought that might conflict with a hypothetical function to get a module by name non-mutably...)
- Should there also be a function to optionally index a module by name immutably? I didn't see a use-case for this immediately but thought we _might_ want something like that for completeness sake, by analogy to `module_mut`. If so, what should it (and the method currently named `module_mut`) be called --- `module`/`module_mut`? `get_module`/`get_module_mut`?