### PR TITLE
Issue #3 and #4: Add field documentation and annotation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub struct Field {
     documentation: String,
 
     /// Field annotation
-    annotation: String,
+    annotation: Vec<String>,
 }
 
 /// Defines an associated type.
@@ -1100,7 +1100,7 @@ impl Field {
             name: name.into(),
             ty: ty.into(),
             documentation: String::new(),
-            annotation: String::new(),
+            annotation: Vec::new(),
         }
     }
 
@@ -1111,8 +1111,8 @@ impl Field {
     }
 
     /// Set field's annotation.
-    pub fn annotation(&mut self, annotation: &str) -> &mut Self {
-        self.annotation = annotation.into();
+    pub fn annotation(&mut self, annotation: Vec<&str>) -> &mut Self {
+        self.annotation = annotation.iter().map(|ann| ann.to_string()).collect();
         self
     }
 }
@@ -1142,7 +1142,7 @@ impl Fields {
             name: name.to_string(),
             ty: ty.into(),
             documentation: String::new(),
-            annotation: String::new(),
+            annotation: Vec::new(),
         })
     }
 
@@ -1173,7 +1173,9 @@ impl Fields {
                             write!(fmt, "/// {}\n", f.documentation)?;
                         }
                         if !f.annotation.is_empty() {
-                            write!(fmt, "{}\n", f.annotation)?;
+                            for ann in &f.annotation {
+                                write!(fmt, "{}\n", ann)?;
+                            }
                         }
                         write!(fmt, "{}: ", f.name)?;
                         f.ty.fmt(fmt)?;
@@ -1251,7 +1253,7 @@ impl Impl {
             name: name.to_string(),
             ty: ty.into(),
             documentation: String::new(),
-            annotation: String::new(),
+            annotation: Vec::new(),
         });
 
         self
@@ -1400,7 +1402,7 @@ impl Function {
             // and `annotation` does not make sense for function arguments.
             // Simply use empty strings.
             documentation: String::new(),
-            annotation: String::new(),
+            annotation: Vec::new(),
         });
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1111,7 +1111,7 @@ impl Field {
     }
 
     /// Set field's annotation.
-    pub fn with_annotation(&mut self, annotation: &str) -> &mut Self {
+    pub fn annotation(&mut self, annotation: &str) -> &mut Self {
         self.annotation = annotation.into();
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1083,6 +1083,21 @@ impl AssociatedType {
     }
 }
 
+// ===== impl Field =====
+
+impl Field {
+    /// Return a field definition with the provided name and type
+    pub fn new<T>(name: &str, ty: T) -> Self
+    where T: Into<Type>,
+    {
+        Field {
+            name: name.into(),
+            ty: ty.into(),
+        }
+    }
+
+}
+
 // ===== impl Fields =====
 
 impl Fields {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ enum Fields {
 
 /// Defines a struct field.
 #[derive(Debug, Clone)]
-struct Field {
+pub struct Field {
     /// Field name
     name: String,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,7 +1105,7 @@ impl Field {
     }
 
     /// Set field's documentation.
-    pub fn with_documentation(&mut self, documentation: &str) -> &mut Self {
+    pub fn doc(&mut self, documentation: &str) -> &mut Self {
         self.documentation = documentation.into();
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,9 @@ pub struct Field {
 
     /// Field documentation
     documentation: String,
+
+    /// Field annotation
+    annotation: String,
 }
 
 /// Defines an associated type.
@@ -1097,6 +1100,7 @@ impl Field {
             name: name.into(),
             ty: ty.into(),
             documentation: String::new(),
+            annotation: String::new(),
         }
     }
 
@@ -1106,6 +1110,11 @@ impl Field {
         self
     }
 
+    /// Set field's annotation.
+    pub fn with_annotation(&mut self, annotation: &str) -> &mut Self {
+        self.annotation = annotation.into();
+        self
+    }
 }
 
 // ===== impl Fields =====
@@ -1133,6 +1142,7 @@ impl Fields {
             name: name.to_string(),
             ty: ty.into(),
             documentation: String::new(),
+            annotation: String::new(),
         })
     }
 
@@ -1161,6 +1171,9 @@ impl Fields {
                     for f in fields {
                         if !f.documentation.is_empty() {
                             write!(fmt, "/// {}\n", f.documentation)?;
+                        }
+                        if !f.annotation.is_empty() {
+                            write!(fmt, "{}\n", f.annotation)?;
                         }
                         write!(fmt, "{}: ", f.name)?;
                         f.ty.fmt(fmt)?;
@@ -1238,6 +1251,7 @@ impl Impl {
             name: name.to_string(),
             ty: ty.into(),
             documentation: String::new(),
+            annotation: String::new(),
         });
 
         self
@@ -1382,7 +1396,11 @@ impl Function {
         self.args.push(Field {
             name: name.to_string(),
             ty: ty.into(),
+            // While a `Field` is used here, both `documentation`
+            // and `annotation` does not make sense for function arguments.
+            // Simply use empty strings.
             documentation: String::new(),
+            annotation: String::new(),
         });
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1101,26 +1101,28 @@ impl Field {
 // ===== impl Fields =====
 
 impl Fields {
-    fn named<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where T: Into<Type>,
+    fn push_named(&mut self, field: Field) -> &mut Self
     {
         match *self {
             Fields::Empty => {
-                *self = Fields::Named(vec![Field {
-                    name: name.to_string(),
-                    ty: ty.into(),
-                }]);
+                *self = Fields::Named(vec![field]);
             }
             Fields::Named(ref mut fields) => {
-                fields.push(Field {
-                    name: name.to_string(),
-                    ty: ty.into(),
-                });
+                fields.push(field);
             }
             _ => panic!("field list is named"),
-        }
+        };
 
         self
+    }
+
+    fn named<T>(&mut self, name: &str, ty: T) -> &mut Self
+    where T: Into<Type>,
+    {
+        self.push_named(Field {
+            name: name.to_string(),
+            ty: ty.into(),
+        })
     }
 
     fn tuple<T>(&mut self, ty: T) -> &mut Self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct Field {
     ty: Type,
 
     /// Field documentation
-    documentation: String,
+    documentation: Vec<String>,
 
     /// Field annotation
     annotation: Vec<String>,
@@ -1099,14 +1099,14 @@ impl Field {
         Field {
             name: name.into(),
             ty: ty.into(),
-            documentation: String::new(),
+            documentation: Vec::new(),
             annotation: Vec::new(),
         }
     }
 
     /// Set field's documentation.
-    pub fn doc(&mut self, documentation: &str) -> &mut Self {
-        self.documentation = documentation.into();
+    pub fn doc(&mut self, documentation: Vec<&str>) -> &mut Self {
+        self.documentation = documentation.iter().map(|doc| doc.to_string()).collect();
         self
     }
 
@@ -1141,7 +1141,7 @@ impl Fields {
         self.push_named(Field {
             name: name.to_string(),
             ty: ty.into(),
-            documentation: String::new(),
+            documentation: Vec::new(),
             annotation: Vec::new(),
         })
     }
@@ -1170,7 +1170,9 @@ impl Fields {
                 fmt.block(|fmt| {
                     for f in fields {
                         if !f.documentation.is_empty() {
-                            write!(fmt, "/// {}\n", f.documentation)?;
+                            for doc in &f.documentation {
+                                write!(fmt, "/// {}\n", doc)?;
+                            }
                         }
                         if !f.annotation.is_empty() {
                             for ann in &f.annotation {
@@ -1252,7 +1254,7 @@ impl Impl {
         self.assoc_tys.push(Field {
             name: name.to_string(),
             ty: ty.into(),
-            documentation: String::new(),
+            documentation: Vec::new(),
             annotation: Vec::new(),
         });
 
@@ -1401,7 +1403,7 @@ impl Function {
             // While a `Field` is used here, both `documentation`
             // and `annotation` does not make sense for function arguments.
             // Simply use empty strings.
-            documentation: String::new(),
+            documentation: Vec::new(),
             annotation: Vec::new(),
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ pub struct Field {
 
     /// Field type
     ty: Type,
+
+    /// Field documentation
+    documentation: String,
 }
 
 /// Defines an associated type.
@@ -1093,7 +1096,14 @@ impl Field {
         Field {
             name: name.into(),
             ty: ty.into(),
+            documentation: String::new(),
         }
+    }
+
+    /// Set field's documentation.
+    pub fn with_documentation(&mut self, documentation: &str) -> &mut Self {
+        self.documentation = documentation.into();
+        self
     }
 
 }
@@ -1122,6 +1132,7 @@ impl Fields {
         self.push_named(Field {
             name: name.to_string(),
             ty: ty.into(),
+            documentation: String::new(),
         })
     }
 
@@ -1148,6 +1159,9 @@ impl Fields {
 
                 fmt.block(|fmt| {
                     for f in fields {
+                        if !f.documentation.is_empty() {
+                            write!(fmt, "/// {}\n", f.documentation)?;
+                        }
                         write!(fmt, "{}: ", f.name)?;
                         f.ty.fmt(fmt)?;
                         write!(fmt, ",\n")?;
@@ -1223,6 +1237,7 @@ impl Impl {
         self.assoc_tys.push(Field {
             name: name.to_string(),
             ty: ty.into(),
+            documentation: String::new(),
         });
 
         self
@@ -1367,6 +1382,7 @@ impl Function {
         self.args.push(Field {
             name: name.to_string(),
             ty: ty.into(),
+            documentation: String::new(),
         });
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,7 +1130,7 @@ impl Fields {
                 fields.push(field);
             }
             _ => panic!("field list is named"),
-        };
+        }
 
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,6 +582,16 @@ impl Struct {
         self
     }
 
+    /// Push a named field to the struct.
+    ///
+    /// A struct can either set named fields with this function or tuple fields
+    /// with `push_tuple_field`, but not both.
+    pub fn push_field(&mut self, field: Field) -> &mut Self
+    {
+        self.fields.push_named(field);
+        self
+    }
+
     /// Add a named field to the struct.
     ///
     /// A struct can either set named fields with this function or tuple fields

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -43,6 +43,28 @@ struct Foo {
 }
 
 #[test]
+fn single_struct_documented_field() {
+    let mut scope = Scope::new();
+
+    let doc = "Field's documentation";
+
+    let mut struct_ = Struct::new("Foo");
+
+    let mut field1 = Field::new("one", "usize");
+    field1.with_documentation(doc);
+
+    scope.push_struct(struct_);
+
+    let expect = r#"
+struct Foo {
+    /// Field's documentation
+    one: usize,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
 fn empty_struct() {
     let mut scope = Scope::new();
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -47,11 +47,21 @@ fn single_struct_documented_field() {
     let mut scope = Scope::new();
 
     let doc = "Field's documentation";
+    let anot = r#"#[serde(rename = "bar")]"#;
 
     let mut struct_ = Struct::new("Foo");
 
     let mut field1 = Field::new("one", "usize");
     field1.with_documentation(doc);
+    struct_.push_field(field1);
+
+    let mut field2 = Field::new("two", "usize");
+    field2.with_annotation(anot);
+    struct_.push_field(field2);
+
+    let mut field3 = Field::new("three", "usize");
+    field3.with_documentation(doc).with_annotation(anot);
+    struct_.push_field(field3);
 
     scope.push_struct(struct_);
 
@@ -59,6 +69,11 @@ fn single_struct_documented_field() {
 struct Foo {
     /// Field's documentation
     one: usize,
+    #[serde(rename = "bar")]
+    two: usize,
+    /// Field's documentation
+    #[serde(rename = "bar")]
+    three: usize,
 }"#;
 
     assert_eq!(scope.to_string(), &expect[1..]);

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -46,12 +46,12 @@ struct Foo {
 fn single_struct_documented_field() {
     let mut scope = Scope::new();
 
-    let doc = "Field's documentation";
+    let doc = vec!["Field's documentation", "Second line"];
 
     let mut struct_ = Struct::new("Foo");
 
     let mut field1 = Field::new("one", "usize");
-    field1.doc(doc);
+    field1.doc(doc.clone());
     struct_.push_field(field1);
 
     let mut field2 = Field::new("two", "usize");
@@ -70,10 +70,12 @@ fn single_struct_documented_field() {
     let expect = r#"
 struct Foo {
     /// Field's documentation
+    /// Second line
     one: usize,
     #[serde(rename = "bar")]
     two: usize,
     /// Field's documentation
+    /// Second line
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
     three: usize,

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,6 +1,6 @@
 extern crate codegen;
 
-use codegen::Scope;
+use codegen::{Field, Scope, Struct};
 
 #[test]
 fn empty_scope() {
@@ -21,6 +21,22 @@ fn single_struct() {
 struct Foo {
     one: usize,
     two: String,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn struct_with_pushed_field() {
+    let mut scope = Scope::new();
+    let mut struct_ = Struct::new("Foo");
+    let mut field = Field::new("one", "usize");
+    struct_.push_field(field);
+    scope.push_struct(struct_);
+
+    let expect = r#"
+struct Foo {
+    one: usize,
 }"#;
 
     assert_eq!(scope.to_string(), &expect[1..]);

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -52,15 +52,15 @@ fn single_struct_documented_field() {
     let mut struct_ = Struct::new("Foo");
 
     let mut field1 = Field::new("one", "usize");
-    field1.with_documentation(doc);
+    field1.doc(doc);
     struct_.push_field(field1);
 
     let mut field2 = Field::new("two", "usize");
-    field2.with_annotation(anot);
+    field2.annotation(anot);
     struct_.push_field(field2);
 
     let mut field3 = Field::new("three", "usize");
-    field3.with_documentation(doc).with_annotation(anot);
+    field3.doc(doc).annotation(anot);
     struct_.push_field(field3);
 
     scope.push_struct(struct_);

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -47,7 +47,6 @@ fn single_struct_documented_field() {
     let mut scope = Scope::new();
 
     let doc = "Field's documentation";
-    let anot = r#"#[serde(rename = "bar")]"#;
 
     let mut struct_ = Struct::new("Foo");
 
@@ -56,11 +55,14 @@ fn single_struct_documented_field() {
     struct_.push_field(field1);
 
     let mut field2 = Field::new("two", "usize");
-    field2.annotation(anot);
+    field2.annotation(vec![r#"#[serde(rename = "bar")]"#]);
     struct_.push_field(field2);
 
     let mut field3 = Field::new("three", "usize");
-    field3.doc(doc).annotation(anot);
+    field3.doc(doc).annotation(vec![
+        r#"#[serde(skip_serializing)]"#,
+        r#"#[serde(skip_deserializing)]"#,
+    ]);
     struct_.push_field(field3);
 
     scope.push_struct(struct_);
@@ -72,7 +74,8 @@ struct Foo {
     #[serde(rename = "bar")]
     two: usize,
     /// Field's documentation
-    #[serde(rename = "bar")]
+    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
     three: usize,
 }"#;
 


### PR DESCRIPTION
This PR adds two fields to the `Field` struct to set a struct field's documentation and annotation.

The `Field` type must be `pub` to be created outside of the crate.

A `Struct::push_field()` function is added to add the manually created field to the struct.

I also split `Fields::named()` into `named()` and `push_named()` (see 6093af4) to be able to reuse the latter.

This PR is a work in progress. I haven't added the modification to tuple fields since their content is a different type (`Type` instead of `Field`). I'd like to make sure this is a proper path before continuing. Maybe the doc and annotation could go inside the `Type` instead?

Should close #3 and #4.