### PR TITLE
Fix handling of namespaced imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,29 +258,11 @@ impl Scope {
     pub fn import(&mut self, path: &str, ty: &str) -> &mut Import {
         // handle cases where the caller wants to refer to a type namespaced
         // within the containing namespace, like "a::B".
-        let import_target = match ty.matches("::").count() {
-            0 =>
-                // if there are 0 occurances of "::" in the imported type,
-                // it's a bare name. we're fine.
-                ty,
-            1 =>
-                // if we're referring to the type as namespaced in the
-                // containing module, such as `module::Type`, rather
-                // than with just the bare name, just import the containing
-                // scope -- skip importing the actual type.
-                ty.split("::").next()
-                  .expect("attempted to import a type that was just \"::\""),
-            _ =>
-                // the type contained multiple instances of "::". eventually,
-                // we could possibly handle this by pushing some of them to
-                // the path, but it's unclear how the caller expects to refer
-                // to that type. for now, don't try and figure it out.
-                unimplemented!("type name with multiple \"::\"s.")
-        };
+        let ty = ty.split("::").next().unwrap_or(ty);
         self.imports.entry(path.to_string())
             .or_insert(OrderMap::new())
-            .entry(import_target.to_string())
-            .or_insert_with(|| Import::new(path, import_target))
+            .entry(ty.to_string())
+            .or_insert_with(|| Import::new(path, ty))
     }
 
     /// Push a new module definition, returning a mutable reference to it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1375,8 +1375,18 @@ impl Impl {
 impl Import {
     /// Return a new import.
     pub fn new(path: &str, ty: &str) -> Self {
+        let line =
+            if ty.contains("::") {
+                // if we're referring to the type as namespaced in the
+                // containing module, such as `module::Type`, rather
+                // than with just the bare name, just import the containing
+                // scope -- skip importing the actual type.
+                path
+            } else {
+                format!("{}::{}", path, ty)
+            };
         Import {
-            line: format!("{}::{}", path, ty),
+            line,
             vis: None,
         }
     }

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -258,18 +258,22 @@ fn scoped_imports() {
     scope.new_module("foo")
         .import("bar", "Bar")
         .import("bar", "baz::Baz")
+        .import("bar::quux", "quuux::Quuuux")
         .new_struct("Foo")
         .field("bar", "Bar")
         .field("baz", "baz::Baz")
+        .field("quuuux", "quuux::Quuuux")
         ;
 
     let expect = r#"
 mod foo {
     use bar::{Bar, baz};
+    use bar::quux::quuux;
 
     struct Foo {
         bar: Bar,
         baz: baz::Baz,
+        quuuux: quuux::Quuuux,
     }
 }"#;
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -253,6 +253,30 @@ mod foo {
 
 
 #[test]
+fn scoped_imports() {
+    let mut scope = Scope::new();
+    scope.new_module("foo")
+        .import("bar", "Bar")
+        .import("bar", "baz::Baz")
+        .new_struct("Foo")
+        .field("bar", "Bar")
+        .field("baz", "baz::Baz")
+        ;
+
+    let expect = r#"
+mod foo {
+    use bar::{Bar, baz};
+
+    struct Foo {
+        bar: Bar,
+        baz: baz::Baz,
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
 fn module_mut() {
     let mut scope = Scope::new();
     scope.new_module("foo")


### PR DESCRIPTION
Previously, `Scope.import()` would not properly handle the case where the imported type is namespaced, as in `foo::Bar`. In this case, the output code would include `use` statements like `use baz::{bar, foo::Bar};`, which is invalid. Handling these cases correctly is necessary for some downstream changes required by an in-progress fix for tower-rs/tower-grpc#33.

This PR improves the handling of scoped imports, and adds a unit test for correct behaviour.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>