### PR TITLE
Add repr to struct and enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ struct TypeDef {
     docs: Option<Docs>,
     derive: Vec<String>,
     allow: Option<String>,
+    repr: Option<String>,
     bounds: Vec<Bound>,
 }
 
@@ -705,6 +706,12 @@ impl Struct {
         self
     }
 
+    /// Specify representation.
+    pub fn repr(&mut self, repr: &str) -> &mut Self {
+        self.type_def.repr(repr);
+        self
+    }
+
     /// Add a named field to the struct.
     ///
     /// A struct can either set named fields with this function or tuple fields
@@ -912,6 +919,12 @@ impl Enum {
         self
     }
 
+    /// Specify representation.
+    pub fn repr(&mut self, repr: &str) -> &mut Self {
+        self.type_def.repr(repr);
+        self
+    }
+
     /// Push a variant to the enum, returning a mutable reference to it.
     pub fn new_variant(&mut self, name: &str) -> &mut Variant {
         self.push_variant(Variant::new(name));
@@ -1072,6 +1085,7 @@ impl TypeDef {
             docs: None,
             derive: vec![],
             allow: None,
+            repr: None,
             bounds: vec![],
         }
     }
@@ -1101,6 +1115,10 @@ impl TypeDef {
         self.allow = Some(allow.to_string());
     }
 
+    fn repr(&mut self, repr: &str) {
+        self.repr = Some(repr.to_string());
+    }
+
     fn fmt_head(&self,
                 keyword: &str,
                 parents: &[Type],
@@ -1112,6 +1130,7 @@ impl TypeDef {
 
         self.fmt_allow(fmt)?;
         self.fmt_derive(fmt)?;
+        self.fmt_repr(fmt)?;
 
         if let Some(ref vis) = self.vis {
             write!(fmt, "{} ", vis)?;
@@ -1140,6 +1159,14 @@ impl TypeDef {
     fn fmt_allow(&self, fmt: &mut Formatter) -> fmt::Result {
         if let Some(ref allow) = self.allow {
             write!(fmt, "#[allow({})]\n", allow)?;
+        }
+
+        Ok(())
+    }
+
+    fn fmt_repr(&self, fmt: &mut Formatter) -> fmt::Result {
+        if let Some(ref repr) = self.repr {
+            write!(fmt, "#[repr({})]\n", repr)?;
         }
 
         Ok(())

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -82,6 +82,25 @@ struct Foo {
 }
 
 #[test]
+fn struct_with_repr() {
+    let mut scope = Scope::new();
+
+    scope.new_struct("Foo")
+        .repr("C")
+        .field("one", "u8")
+        .field("two", "u8");
+
+    let expect = r#"
+#[repr(C)]
+struct Foo {
+    one: u8,
+    two: u8,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
 fn struct_with_allow() {
     let mut scope = Scope::new();
 
@@ -270,6 +289,25 @@ mod foo {
     assert_eq!(scope.to_string(), &expect[1..]);
 }
 
+#[test]
+fn enum_with_repr() {
+    let mut scope = Scope::new();
+
+    scope.new_enum("IpAddrKind")
+        .repr("u8")
+        .push_variant(Variant::new("V4"))
+        .push_variant(Variant::new("V6"))
+        ;
+
+    let expect = r#"
+#[repr(u8)]
+enum IpAddrKind {
+    V4,
+    V6,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
 
 #[test]
 fn enum_with_allow() {


### PR DESCRIPTION
This adds support for `#[repr(...)]` in enums and structs.