### PR TITLE
Add allow for specifying lint attributes

### DIFF
--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,6 +1,6 @@
 extern crate codegen;
 
-use codegen::Scope;
+use codegen::{Scope, Variant};
 
 #[test]
 fn empty_scope() {
@@ -76,6 +76,25 @@ fn struct_with_derive() {
 struct Foo {
     one: usize,
     two: String,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn struct_with_allow() {
+    let mut scope = Scope::new();
+
+    scope.new_struct("Foo")
+        .allow("dead_code")
+        .field("one", "u8")
+        .field("two", "u8");
+
+    let expect = r#"
+#[allow(dead_code)]
+struct Foo {
+    one: u8,
+    two: u8,
 }"#;
 
     assert_eq!(scope.to_string(), &expect[1..]);
@@ -251,6 +270,26 @@ mod foo {
     assert_eq!(scope.to_string(), &expect[1..]);
 }
 
+
+#[test]
+fn enum_with_allow() {
+    let mut scope = Scope::new();
+
+    scope.new_enum("IpAddrKind")
+        .allow("dead_code")
+        .push_variant(Variant::new("V4"))
+        .push_variant(Variant::new("V6"))
+        ;
+
+    let expect = r#"
+#[allow(dead_code)]
+enum IpAddrKind {
+    V4,
+    V6,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
 
 #[test]
 fn scoped_imports() {


### PR DESCRIPTION
Example:

```Rust
 scope.new_struct("Foo")
        .allow("dead_code")
        .field("one", "u8")
```

Output:
```Rust
#[allow(dead_code)]
struct Foo {
    one: u8,
}
```