### PR TITLE
Add ability to define fn as async, also allow for macros in traits and impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub struct Trait {
     parents: Vec<Type>,
     associated_tys: Vec<AssociatedType>,
     fns: Vec<Function>,
+    macros: Vec<String>,
 }
 
 /// Defines a type.
@@ -112,6 +113,7 @@ struct TypeDef {
     allow: Option<String>,
     repr: Option<String>,
     bounds: Vec<Bound>,
+    macros: Vec<String>,
 }
 
 /// Defines an enum variant.
@@ -168,6 +170,8 @@ pub struct Impl {
     bounds: Vec<Bound>,
 
     fns: Vec<Function>,
+
+    macros: Vec<String>,
 }
 
 /// Defines an import (`use` statement).
@@ -209,6 +213,9 @@ pub struct Function {
 
     /// Body contents
     body: Option<Vec<Body>>,
+
+    /// Whether or not this function is `async` or not
+    r#async: bool,
 }
 
 /// Defines a code block. This is used to define a function body.
@@ -763,6 +770,7 @@ impl Trait {
             parents: vec![],
             associated_tys: vec![],
             fns: vec![],
+            macros: vec![],
         }
     }
 
@@ -788,6 +796,12 @@ impl Trait {
     where T: Into<Type>,
     {
         self.type_def.bound(name, ty);
+        self
+    }
+
+    /// Add a macro to the trait def (e.g. `"#[async_trait]"`)
+    pub fn r#macro(&mut self, r#macro: &str) -> &mut Self {
+        self.type_def.r#macro(r#macro);
         self
     }
 
@@ -1087,6 +1101,7 @@ impl TypeDef {
             allow: None,
             repr: None,
             bounds: vec![],
+            macros: vec![],
         }
     }
 
@@ -1101,6 +1116,10 @@ impl TypeDef {
             name: name.to_string(),
             bound: vec![ty.into()],
         });
+    }
+
+    fn r#macro(&mut self, r#macro: &str) {
+        self.macros.push(r#macro.to_string());
     }
 
     fn doc(&mut self, docs: &str) {
@@ -1131,6 +1150,7 @@ impl TypeDef {
         self.fmt_allow(fmt)?;
         self.fmt_derive(fmt)?;
         self.fmt_repr(fmt)?;
+        self.fmt_macros(fmt)?;
 
         if let Some(ref vis) = self.vis {
             write!(fmt, "{} ", vis)?;
@@ -1184,6 +1204,13 @@ impl TypeDef {
             write!(fmt, ")]\n")?;
         }
 
+        Ok(())
+    }
+
+    fn fmt_macros(&self, fmt: &mut Formatter) -> fmt::Result {
+        for m in self.macros.iter() {
+            write!(fmt, "{}\n", m)?;
+        }
         Ok(())
     }
 }
@@ -1332,6 +1359,7 @@ impl Impl {
             assoc_tys: vec![],
             bounds: vec![],
             fns: vec![],
+            macros: vec![],
         }
     }
 
@@ -1356,6 +1384,12 @@ impl Impl {
     where T: Into<Type>,
     {
         self.impl_trait = Some(ty.into());
+        self
+    }
+
+    /// Add a macro to the impl block (e.g. `"#[async_trait]"`)
+    pub fn r#macro(&mut self, r#macro: &str) -> &mut Self {
+        self.macros.push(r#macro.to_string());
         self
     }
 
@@ -1396,6 +1430,9 @@ impl Impl {
 
     /// Formats the impl block using the given formatter.
     pub fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        for m in self.macros.iter() {
+            write!(fmt, "{}\n", m)?;
+        }
         write!(fmt, "impl")?;
         fmt_generics(&self.generics[..], fmt)?;
 
@@ -1465,6 +1502,7 @@ impl Function {
             ret: None,
             bounds: vec![],
             body: Some(vec![]),
+            r#async: false,
         }
     }
 
@@ -1483,6 +1521,12 @@ impl Function {
     /// Set the function visibility.
     pub fn vis(&mut self, vis: &str) -> &mut Self {
         self.vis = Some(vis.to_string());
+        self
+    }
+
+    /// Set whether this function is async or not
+    pub fn set_async(&mut self, r#async: bool) -> &mut Self {
+        self.r#async = r#async;
         self
     }
 
@@ -1575,6 +1619,10 @@ impl Function {
 
         if let Some(ref vis) = self.vis {
             write!(fmt, "{} ", vis)?;
+        }
+
+        if self.r#async {
+            write!(fmt, "async ")?;
         }
 
         write!(fmt, "fn {}", self.name)?;

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -406,3 +406,72 @@ mod foo {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+#[test]
+fn function_with_async() {
+    let mut scope = Scope::new();
+    let trt = scope.new_trait("Foo");
+
+    let f = trt.new_fn("pet_toby");
+    f.set_async(true);
+    f.line("println!(\"petting toby because he is a good boi\");");
+
+    let expect = r#"
+trait Foo {
+    async fn pet_toby() {
+        println!("petting toby because he is a good boi");
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn trait_with_macros() {
+    let mut scope = Scope::new();
+    let trt = scope.new_trait("Foo");
+    trt.r#macro("#[async_trait]");
+    trt.r#macro("#[toby_is_cute]");
+
+    let f = trt.new_fn("pet_toby");
+    f.set_async(true);
+    f.line("println!(\"petting toby because he is a good boi\");");
+
+    let expect = r#"
+#[async_trait]
+#[toby_is_cute]
+trait Foo {
+    async fn pet_toby() {
+        println!("petting toby because he is a good boi");
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn impl_with_macros() {
+    let mut scope = Scope::new();
+    scope.new_struct("Bar");
+    let imp = scope.new_impl("Bar");
+    imp.impl_trait("Foo");
+    imp.r#macro("#[async_trait]");
+    imp.r#macro("#[toby_is_cute]");
+
+    let f = imp.new_fn("pet_toby");
+    f.set_async(true);
+    f.line("println!(\"petting toby because he is a good boi\");");
+
+    let expect = r#"
+struct Bar;
+
+#[async_trait]
+#[toby_is_cute]
+impl Foo for Bar {
+    async fn pet_toby() {
+        println!("petting Toby many times because he is such a good boi");
+    }
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -460,7 +460,7 @@ fn impl_with_macros() {
 
     let f = imp.new_fn("pet_toby");
     f.set_async(true);
-    f.line("println!(\"petting toby because he is a good boi\");");
+    f.line("println!(\"petting Toby many times because he is such a good boi\");");
 
     let expect = r#"
 struct Bar;


### PR DESCRIPTION
As described above, I'd like to add async support and macro support. My use case is that I'd like to use codegen w/ async fns, in addition to using the `#[async_trait]` macro [1]

Ergonomically I don't love using `r#macro` in the code, but I also don't like avoiding using a good name just cuz its reserved. Thoughts on that, or thoughts on other parts of the code would be appreciated. Thx!

[1] https://github.com/dtolnay/async-trait