### PR TITLE
Added Support For Struct Attributes

### DIFF
--- a/src/struct.rs
+++ b/src/struct.rs
@@ -14,6 +14,9 @@ pub struct Struct {
 
     /// Struct fields
     fields: Fields,
+
+    /// The attributes for this struct.
+    attributes: Vec<String>,
 }
 
 impl Struct {
@@ -22,6 +25,7 @@ impl Struct {
         Struct {
             type_def: TypeDef::new(name),
             fields: Fields::Empty,
+            attributes: vec![],
         }
     }
 
@@ -60,6 +64,12 @@ impl Struct {
     /// Add a new type that the struct should derive.
     pub fn derive(&mut self, name: &str) -> &mut Self {
         self.type_def.derive(name);
+        self
+    }
+
+    /// Adds an attribute to the struct (e.g. `"#[some_attribute]"`)
+    pub fn attribute(&mut self, attribute: &str) -> &mut Self {
+        self.attributes.push(attribute.to_string());
         self
     }
 
@@ -110,6 +120,9 @@ impl Struct {
 
     /// Formats the struct using the given formatter.
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        for m in self.attributes.iter() {
+            write!(fmt, "{}\n", m)?;
+        }
         self.type_def.fmt_head("struct", &[], fmt)?;
         self.fields.fmt(fmt)?;
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -42,6 +42,44 @@ struct Foo {
 }
 
 #[test]
+fn struct_with_attribute() {
+    let mut scope = Scope::new();
+    let mut struct_ = Struct::new("Foo");
+    let field = Field::new("one", "usize");
+    struct_.push_field(field);
+    struct_.attribute("#[test]");
+    scope.push_struct(struct_);
+
+    let expect = r#"
+#[test]
+struct Foo {
+    one: usize,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn struct_with_multiple_attributes() {
+    let mut scope = Scope::new();
+    let mut struct_ = Struct::new("Foo");
+    let field = Field::new("one", "usize");
+    struct_.push_field(field);
+    struct_.attribute("#[test]");
+    struct_.attribute("#[cfg(target_os = \"linux\")]");
+    scope.push_struct(struct_);
+
+    let expect = r#"
+#[test]
+#[cfg(target_os = "linux")]
+struct Foo {
+    one: usize,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
 fn single_struct_documented_field() {
     let mut scope = Scope::new();
 


### PR DESCRIPTION
- Can add one or more attributes to a struct with `.attribute`
- Added tests for one and multiple attributes added to a struct.