### PR TITLE
Added support for associated constants on traits and impls

### DIFF
--- a/src/associated_constant.rs
+++ b/src/associated_constant.rs
@@ -1,0 +1,42 @@
+use std::fmt::{self, Write};
+use crate::formatter::Formatter;
+
+/// Defines an associated constant for use in impls and traits
+#[derive(Clone, Debug)]
+pub struct AssociatedConstant {
+    name: String,
+    datatype: crate::r#type::Type,
+    value: Option<String>,
+}
+
+impl AssociatedConstant {
+    /// Returns an associated constant with the given name and datatype
+    pub fn new<Datatype>(name: &str, datatype: Datatype) -> Self
+    where
+        Datatype: Into<crate::r#type::Type>
+    {
+        Self {
+            name: name.into(),
+            datatype: datatype.into(),
+            value: None,
+        }
+    }
+
+    /// Adds a value expression to the associated constant
+    pub fn value(&mut self, expression: &str) -> &mut Self {
+        self.value = Some(expression.to_string());
+        self
+    }
+
+    /// Formats the scope using the given formatter.
+    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        let value_expression = match &self.value {
+            Some(expression) => format!(" = {};", expression),
+            None => ";".to_string(),
+        };
+        write!(fmt, "const {}: ", self.name)?;
+        self.datatype.fmt(fmt)?;
+        write!(fmt, "{}", value_expression)?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! println!("{}", scope.to_string());
 //! ```
 
+mod associated_constant;
 mod associated_type;
 mod block;
 mod body;
@@ -48,6 +49,7 @@ mod r#trait;
 mod r#type;
 
 
+pub use associated_constant::*;
 pub use associated_type::*;
 pub use block::*;
 pub use field::*;

--- a/src/trait.rs
+++ b/src/trait.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Write};
 
+use crate::AssociatedConstant;
 use crate::associated_type::AssociatedType;
 use crate::bound::Bound;
 use crate::formatter::{fmt_bound_rhs, Formatter};
@@ -14,6 +15,7 @@ pub struct Trait {
     type_def: TypeDef,
     parents: Vec<Type>,
     associated_tys: Vec<AssociatedType>,
+    associated_constants: Vec<AssociatedConstant>,
     fns: Vec<Function>,
     macros: Vec<String>,
 }
@@ -25,6 +27,7 @@ impl Trait {
             type_def: TypeDef::new(name),
             parents: vec![],
             associated_tys: vec![],
+            associated_constants: vec![],
             fns: vec![],
             macros: vec![],
         }
@@ -88,6 +91,25 @@ impl Trait {
         self.associated_tys.last_mut().unwrap()
     }
 
+    /// Push an associated constant to the trait block
+    pub fn push_associated_constant(&mut self, constant: AssociatedConstant) -> &mut Self
+    {
+        self.associated_constants.push(constant);
+        self
+    }
+
+
+    /// Create an associated constant for the trait block
+    pub fn new_associated_constant<Type>(&mut self, name: &str, datatype: Type) -> &mut AssociatedConstant
+    where
+        Type: Into<crate::r#type::Type>
+    {
+        self.push_associated_constant(
+            AssociatedConstant::new(name, datatype));
+
+        self.associated_constants.last_mut().unwrap()
+    }
+
     /// Push a new function definition, returning a mutable reference to it.
     pub fn new_fn(&mut self, name: &str) -> &mut Function {
         let mut func = Function::new(name);
@@ -123,6 +145,13 @@ impl Trait {
                     }
 
                     write!(fmt, ";\n")?;
+                }
+            }
+
+            if !self.associated_constants.is_empty() {
+                for constant in &self.associated_constants {
+                    constant.fmt(fmt)?;
+                    write!(fmt, "\n")?;
                 }
             }
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -605,3 +605,51 @@ enum IpAddrKind {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+#[test]
+fn impl_with_associated_constants() {
+    let mut scope = Scope::new();
+
+    let constant1 = AssociatedConstant::new("BAR", "usize");
+    let mut constant2 = AssociatedConstant::new("BAZ", "i16");
+    constant2.value("22");
+
+    let current_impl = scope.new_impl("Foo")
+        .push_associated_constant(constant1)
+        .push_associated_constant(constant2);
+
+    current_impl.new_associated_constant("QUX", "usize").value("43");
+
+    let expect = r#"
+impl Foo {
+    const BAR: usize;
+    const BAZ: i16 = 22;
+    const QUX: usize = 43;
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}
+
+#[test]
+fn trait_with_associated_constants() {
+    let mut scope = Scope::new();
+
+    let constant1 = AssociatedConstant::new("BAR", "usize");
+    let mut constant2 = AssociatedConstant::new("BAZ", "i16");
+    constant2.value("22");
+
+    let current_trait = scope.new_trait("Foo")
+        .push_associated_constant(constant1)
+        .push_associated_constant(constant2);
+
+    current_trait.new_associated_constant("QUX", "usize").value("43");
+
+    let expect = r#"
+trait Foo {
+    const BAR: usize;
+    const BAZ: i16 = 22;
+    const QUX: usize = 43;
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}


### PR DESCRIPTION
- Supports both `push` and `new`(builder pattern) functions for adding associated constants.
- Supports assigning a value to an associated constant.
- Also added tests for all the new functionality.

Fixes #27 