### PR TITLE
Added support for visibility for fields

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -14,6 +14,9 @@ pub struct Field {
 
     /// Field annotation
     pub annotation: Vec<String>,
+
+    /// The visibility of the field
+    pub visibility: Option<String>,
 }
 
 impl Field {
@@ -27,6 +30,7 @@ impl Field {
             ty: ty.into(),
             documentation: Vec::new(),
             annotation: Vec::new(),
+            visibility: None,
         }
     }
 
@@ -39,6 +43,12 @@ impl Field {
     /// Set field's annotation.
     pub fn annotation(&mut self, annotation: Vec<&str>) -> &mut Self {
         self.annotation = annotation.iter().map(|ann| ann.to_string()).collect();
+        self
+    }
+
+    /// Set the visibility of the field
+    pub fn vis(&mut self, visibility: &str) -> &mut Self {
+        self.visibility = Some(visibility.to_string());
         self
     }
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -37,7 +37,21 @@ impl Fields {
             ty: ty.into(),
             documentation: Vec::new(),
             annotation: Vec::new(),
+            visibility: None,
         })
+    }
+
+    pub fn new_named<T>(&mut self, name: &str, ty: T) -> &mut Field
+    where
+        T: Into<Type>,
+    {
+        self.named(name, ty);
+        if let Fields::Named(ref mut fields) = *self {
+            fields.last_mut().unwrap()
+        }
+        else {
+            unreachable!()
+        }
     }
 
     pub fn tuple<T>(&mut self, ty: T) -> &mut Self
@@ -73,6 +87,9 @@ impl Fields {
                             for ann in &f.annotation {
                                 write!(fmt, "{}\n", ann)?;
                             }
+                        }
+                        if let Some(visibility) = &f.visibility {
+                            write!(fmt, "{} ", visibility)?;
                         }
                         write!(fmt, "{}: ", f.name)?;
                         f.ty.fmt(fmt)?;

--- a/src/function.rs
+++ b/src/function.rs
@@ -129,11 +129,12 @@ impl Function {
         self.args.push(Field {
             name: name.to_string(),
             ty: ty.into(),
-            // While a `Field` is used here, both `documentation`
+            // While a `Field` is used here, both `documentation`, `visibility`
             // and `annotation` does not make sense for function arguments.
             // Simply use empty strings.
             documentation: Vec::new(),
             annotation: Vec::new(),
+            visibility: None,
         });
 
         self

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -89,6 +89,7 @@ impl Impl {
             ty: ty.into(),
             documentation: Vec::new(),
             annotation: Vec::new(),
+            visibility: None,
         });
 
         self

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -96,6 +96,17 @@ impl Struct {
         self
     }
 
+    /// Create a named field for the struct.
+    ///
+    /// A struct can either set named fields with this function or tuple fields
+    /// with `tuple_field`, but not both.
+    pub fn new_field<T>(&mut self, name: &str, ty: T) -> &mut Field
+    where
+        T: Into<Type>,
+    {
+        self.fields.new_named(name, ty)
+    }
+
     /// Add a tuple field to the struct.
     ///
     /// A struct can either set tuple fields with this function or named fields

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -605,3 +605,24 @@ enum IpAddrKind {
 
     assert_eq!(scope.to_string(), &expect[1..]);
 }
+
+#[test]
+fn struct_with_member_visibility() {
+    let mut scope = Scope::new();
+
+    let struct_description = scope.new_struct("Foo");
+
+    let mut bar = Field::new("bar", "usize");
+    bar.vis("pub");
+
+    struct_description.push_field(bar);
+    struct_description.new_field("baz", "i16").vis("pub(crate)");
+
+    let expect = r#"
+struct Foo {
+    pub bar: usize,
+    pub(crate) baz: i16,
+}"#;
+
+    assert_eq!(scope.to_string(), &expect[1..]);
+}


### PR DESCRIPTION
- Added support through the `vis` function like in `function`.
- Added support for `new` field function to support builder pattern for visibility.
- Added test for new functionality.

Fixes #10 