### PR TITLE
Add Hash derive to Type

### DIFF
--- a/src/type.rs
+++ b/src/type.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Write};
 use crate::formatter::Formatter;
 
 /// Defines a type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Type {
     name: String,
     generics: Vec<Type>,


### PR DESCRIPTION
Pretty self explanatory PR.
I wanted to add `codegen::Type` to a `HashSet` but to do that cleanly it would need to impl `Hash`.
I figured someone else might want to do something similar as well so I put together this PR.